### PR TITLE
Debug prod api quick ask 500 error

### DIFF
--- a/src/app/api/ask/quick/route.ts
+++ b/src/app/api/ask/quick/route.ts
@@ -9,6 +9,8 @@ import { askTools } from "@/lib/ai/askTools";
 import { streamText, hasToolCall, ModelMessage } from "ai";
 import { getModel, getApiKeyForProvider } from "aieo";
 
+export const runtime = "nodejs";
+
 type Provider = "anthropic" | "google" | "openai" | "claude_code";
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/ask/route.ts
+++ b/src/app/api/ask/route.ts
@@ -5,6 +5,8 @@ import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import { validateWorkspaceAccess } from "@/services/workspace";
 
+export const runtime = "nodejs";
+
 export async function GET(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);

--- a/src/app/api/gitsee/route.ts
+++ b/src/app/api/gitsee/route.ts
@@ -5,6 +5,8 @@ import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import { validateWorkspaceAccessById } from "@/services/workspace";
 
+export const runtime = "nodejs";
+
 export async function POST(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);

--- a/src/app/api/learnings/route.ts
+++ b/src/app/api/learnings/route.ts
@@ -5,6 +5,8 @@ import { db } from "@/lib/db";
 import { EncryptionService } from "@/lib/encryption";
 import { validateWorkspaceAccess } from "@/services/workspace";
 
+export const runtime = "nodejs";
+
 export async function GET(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);

--- a/src/app/api/swarm/route.ts
+++ b/src/app/api/swarm/route.ts
@@ -10,6 +10,8 @@ import { SwarmStatus } from "@prisma/client";
 import { getServerSession } from "next-auth/next";
 import { NextRequest, NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 export async function POST(request: NextRequest) {
   if (isFakeMode) {
     const { id, swarm_id } = await createFakeSwarm();

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "@/lib/auth/nextauth";
 import { db } from "@/lib/db";
 import { TaskStatus, Priority, WorkflowStatus } from "@prisma/client";
 
+export const runtime = "nodejs";
+
 export async function GET(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "@/lib/auth/nextauth";
 import { createWorkspace, getUserWorkspaces, softDeleteWorkspace } from "@/services/workspace";
 import { db } from "@/lib/db";
 
+export const runtime = "nodejs";
+
 // Prevent caching of user-specific data
 export const dynamic = "force-dynamic";
 


### PR DESCRIPTION
Add `export const runtime = "nodejs"` to several API routes to resolve 500 errors in production.

After a recent middleware removal, several API routes that utilize Node.js-specific features like `getServerSession()` (NextAuth), `EncryptionService` (Node.js crypto), and Prisma database operations defaulted to the Edge Runtime in production. This incompatibility caused 500 errors. Explicitly setting `runtime = "nodejs"` ensures these routes execute in the correct environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc497a38-0079-46eb-8b0f-1993fe281c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc497a38-0079-46eb-8b0f-1993fe281c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

